### PR TITLE
fix(grunt): pre-minifying angular code

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,9 +18,18 @@ module.exports = function(grunt) {
         report: 'gzip'
       },
       build: {
-        src: ['src/hotkeys.js', 'bower_components/mousetrap/mousetrap.js'],
+        src: ['build/hotkeys.js', 'bower_components/mousetrap/mousetrap.js'],
         dest: 'build/hotkeys.min.js'
       }
+    },
+
+    ngmin: {
+      sources: {
+        expand: true,
+        cwd: 'src',
+        src: ['*.js'],
+        dest: 'build'
+      },
     },
 
     cssmin: {
@@ -100,6 +109,7 @@ module.exports = function(grunt) {
   });
 
   grunt.loadNpmTasks('grunt-contrib-uglify');
+  grunt.loadNpmTasks('grunt-ngmin');
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-cssmin');
   grunt.loadNpmTasks('grunt-contrib-concat');
@@ -107,7 +117,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-karma');
   grunt.loadNpmTasks('grunt-karma-coveralls');
 
-  grunt.registerTask('default', ['jshint', 'karma:unit', 'uglify', 'cssmin', 'concat:build', 'coveralls']);
+  grunt.registerTask('default', ['jshint', 'karma:unit', 'ngmin', 'uglify', 'cssmin', 'concat:build', 'coveralls']);
   grunt.registerTask('test', ['karma:watch']);
   grunt.registerTask('build', ['default']);
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "grunt": "~0.4.1",
     "grunt-contrib-jshint": "~0.6.4",
     "grunt-contrib-uglify": "~0.2.4",
+    "grunt-ngmin": "~0.0.3",
     "grunt-contrib-cssmin": "~0.6.1",
     "grunt-karma": "~0.6.2",
     "grunt-contrib-concat": "~0.3.0",


### PR DESCRIPTION
The minified js code throws an error when using the directive _hotkey_:

```
 Unknown provider: aProvider <- a <- hotkeyDirective
```

It's due to the minification of the [line 312](https://github.com/chieffancypants/angular-hotkeys/blob/73c0ec1891fa14cd008710e786225dd0201ee7c4/src/hotkeys.js#L312), it's breaking the AngularJS dependency injection.

Here I'm proposing to add ngmin to pre-minify the source code.
