### PR TITLE
Feature: Optionally allow hotkeys in form elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,3 +187,16 @@ Removes and unbinds a hotkey
 ```js
 hotkeys.del('ctrl+w');
 ```
+
+### Allowing hotkeys in form elements
+By default, Mousetrap prevents hotkey callbacks from firing when their event originates from an `input`, `select`, or `textarea` element. To enable hotkeys in these elements, specify them in the `allowIn` parameter:
+```js
+hotkeys.add({
+  combo: 'ctrl+w',
+  description: 'Description goes here',
+  allowIn: ['INPUT', 'SELECT', 'TEXTAREA'],
+  callback: function(event, hotkey) {
+    event.preventDefault();
+  }
+});
+```

--- a/test/hotkeys.coffee
+++ b/test/hotkeys.coffee
@@ -140,6 +140,93 @@ describe 'Angular Hotkeys', ->
     KeyEvent.simulate('w'.charCodeAt(0), 90)
     expect(executed).toBe true
     expect(passedArg).toBe 'ishmael'
+  
+  it 'should callback when hotkey is pressed in input feild and allowIn is configured', ->
+    executed = no
+    
+    $body = angular.element document.body
+    $input = angular.element '<input/>'
+    $body.prepend $input
+    
+    hotkeys.add
+      combo: 'w'
+      allowIn: ['INPUT']
+      callback: -> executed = yes
+    
+    KeyEvent.simulate('w'.charCodeAt(0), 90, undefined, $input[0])
+    expect(executed).toBe yes
+  
+  it 'should callback when hotkey is pressed in select feild and allowIn is configured', ->
+    executed = no
+    
+    $body = angular.element document.body
+    $select = angular.element '<select/>'
+    $body.prepend $select
+    
+    hotkeys.add
+      combo: 'w'
+      allowIn: ['SELECT']
+      callback: -> executed = yes
+    
+    KeyEvent.simulate('w'.charCodeAt(0), 90, undefined, $select[0])
+    expect(executed).toBe yes
+  
+  it 'should callback when hotkey is pressed in textarea feild and allowIn is configured', ->
+    executed = no
+    
+    $body = angular.element document.body
+    $textarea = angular.element '<textarea/>'
+    $body.prepend $textarea
+    
+    hotkeys.add
+      combo: 'w'
+      allowIn: ['TEXTAREA']
+      callback: -> executed = yes
+    
+    KeyEvent.simulate('w'.charCodeAt(0), 90, undefined, $textarea[0])
+    expect(executed).toBe yes
+  
+  it 'should not callback when hotkey is pressed in input feild', ->
+    executed = no
+    
+    $body = angular.element document.body
+    $input = angular.element '<input/>'
+    $body.prepend $input
+    
+    hotkeys.add
+      combo: 'w'
+      callback: -> executed = yes
+    
+    KeyEvent.simulate('w'.charCodeAt(0), 90, undefined, $input[0])
+    expect(executed).toBe no
+  
+  it 'should not callback when hotkey is pressed in select feild', ->
+    executed = no
+    
+    $body = angular.element document.body
+    $select = angular.element '<select/>'
+    $body.prepend $select
+    
+    hotkeys.add
+      combo: 'w'
+      callback: -> executed = yes
+    
+    KeyEvent.simulate('w'.charCodeAt(0), 90, undefined, $select[0])
+    expect(executed).toBe no
+  
+  it 'should not callback when hotkey is pressed in textarea feild', ->
+    executed = no
+    
+    $body = angular.element document.body
+    $textarea = angular.element '<textarea/>'
+    $body.prepend $textarea
+    
+    hotkeys.add
+      combo: 'w'
+      callback: -> executed = yes
+    
+    KeyEvent.simulate('w'.charCodeAt(0), 90, undefined, $textarea[0])
+    expect(executed).toBe no
 
   it 'should support multiple hotkeys to the same function', ->
     executeCount = 0


### PR DESCRIPTION
By default, Mousetrap prevents hotkey callbacks from firing when their event originates from an `input`, `select`, or `textarea` element. This PR introduces a new parameter for hotkeys.add() called `allowIn` that allows the user to specify an array of elements ('INPUT', 'SELECT', and/or 'TEXTAREA') for which the hotkey will be permitted in. Note that this hotkey will be triggered when the event originates from any other element _or_ the elements listed in `allowIn.` The new parameter is simply a way to enable hotkeys for  `input`, `select`, and/or `textarea` elements.
