### PR TITLE
Hide hotkeys popup until CSS is loaded

### DIFF
--- a/src/hotkeys.css
+++ b/src/hotkeys.css
@@ -1,5 +1,5 @@
 .cfp-hotkeys-container {
-  display: table;
+  display: table !important;
   position: fixed;
   width: 100%;
   height: 100%;

--- a/src/hotkeys.js
+++ b/src/hotkeys.js
@@ -23,7 +23,7 @@
      * Cheat sheet template in the event you want to totally customize it.
      * @type {String}
      */
-    this.template = '<div class="cfp-hotkeys-container fade" ng-class="{in: helpVisible}"><div class="cfp-hotkeys">' +
+    this.template = '<div class="cfp-hotkeys-container fade" ng-class="{in: helpVisible}" style="display: none;"><div class="cfp-hotkeys">' +
                       '<h4 class="cfp-hotkeys-title">{{ title }}</h4>' +
                       '<table><tbody>' +
                         '<tr ng-repeat="hotkey in hotkeys | filter:{ description: \'!$$undefined$$\' }">' +


### PR DESCRIPTION
Addresses Issue #45

Using "display: none;" instead of "visibility: hidden;" to avoid altering page flow.
