### PR TITLE
 Don't assume all routes are handled in Angular

### DIFF
--- a/src/hotkeys.js
+++ b/src/hotkeys.js
@@ -514,7 +514,7 @@
     }];
   })
 
-  .directive('hotkey', function (hotkeys) {
+  .directive('hotkey', ['hotkeys', function (hotkeys) {
     return {
       restrict: 'A',
       link: function (scope, el, attrs) {
@@ -541,11 +541,11 @@
         });
       }
     };
-  })
+  }])
 
-  .run(function(hotkeys) {
+  .run(['hotkeys', function(hotkeys) {
     // force hotkeys to run by injecting it. Without this, hotkeys only runs
     // when a controller or something else asks for it via DI.
-  });
+  }]);
 
 })();


### PR DESCRIPTION
> The routeChangeSuccess event listener assumes that there will be a route. This
> is not the case if the current route isn't defined by Angular and can result in
> JavaScript errors.

I'm working on a very large web application where only particular views are handled by Angular (the rest are handled by a legacy system and in these cases `$routeChangeSuccess` fires with an `undefined` `route`)
