### PR TITLE
Use explicit dependency injection syntax

### DIFF
--- a/src/hotkeys.js
+++ b/src/hotkeys.js
@@ -514,7 +514,7 @@
     }];
   })
 
-  .directive('hotkey', function (hotkeys) {
+  .directive('hotkey', ['hotkeys', function (hotkeys) {
     return {
       restrict: 'A',
       link: function (scope, el, attrs) {
@@ -541,11 +541,11 @@
         });
       }
     };
-  })
+  }])
 
-  .run(function(hotkeys) {
+  .run(['hotkeys', function(hotkeys) {
     // force hotkeys to run by injecting it. Without this, hotkeys only runs
     // when a controller or something else asks for it via DI.
-  });
+  }]);
 
 })();


### PR DESCRIPTION
> In both cases where the `hotkeys` service is injected, use the explicit
> dependency declaration syntax instead of relying on the parameter names.
> 
> This makes the library compatible with variable manglers.

Large projects often concat all their JS into a single file and uglify it. If they mangle variables, angular-hotkeys will break because Angular tries to infer the dependency names from parameters.

**Relevant Angular docs:** [Inline Array Annotation](https://docs.angularjs.org/guide/di#inline-array-annotation)
