### PR TITLE
fix for compiled js dependency injection problems

### DIFF
--- a/src/hotkeys.js
+++ b/src/hotkeys.js
@@ -543,9 +543,9 @@
     };
   })
 
-  .run(function(hotkeys) {
+  .run(['hotkeys', function(hotkeys) {
     // force hotkeys to run by injecting it. Without this, hotkeys only runs
     // when a controller or something else asks for it via DI.
-  });
+  }]);
 
 })();


### PR DESCRIPTION
Without this, compiled javascript (like with uglify) will fail to inject the right thing into the function argument to the .run() command.
