### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,4 +214,4 @@ hotkeys.add({
 
 ## Credits:
 
-Muchos gracias to Craig Campbell for his [Mousetrap](https://github.com/ccampbell/mousetrap) library, which provides the underlying library for handling keyboard shortcuts.
+Muchas gracias to Craig Campbell for his [Mousetrap](https://github.com/ccampbell/mousetrap) library, which provides the underlying library for handling keyboard shortcuts.


### PR DESCRIPTION
'Gracias' is a female word in spanish and correct word before it is muchas instead of muchos.  Sorry about my TOC and this stupid pull request and thanks for the tool
