### PR TITLE
Correctly empty the list of hotkeys on $destroy.

### DIFF
--- a/src/hotkeys.js
+++ b/src/hotkeys.js
@@ -452,8 +452,7 @@
           scope.$on('$destroy', function () {
             var i = boundScopes[scope.$id].length;
             while (i--) {
-              _del(boundScopes[scope.$id][i]);
-              delete boundScopes[scope.$id][i];
+              _del(boundScopes[scope.$id].pop());
             }
           });
         }


### PR DESCRIPTION
The original code with `delete` was just setting each element to `undefined`. This would lead to an error (_TypeError: Cannot read property 'replace' of undefined_) when the `$destroy` event is received more than once. (I can't say why I'm receiving `$destroy` more than once.)
