### PR TITLE
Support multiple description for hotkey directive

### DIFF
--- a/src/hotkeys.js
+++ b/src/hotkeys.js
@@ -529,17 +529,20 @@
     return {
       restrict: 'A',
       link: function (scope, el, attrs) {
-        var key, allowIn;
+        var keys, allowIn, description;
+
+        keys = [];
+        description = scope.$eval(attrs.hotkeyDescription) || {};
 
         angular.forEach(scope.$eval(attrs.hotkey), function (func, hotkey) {
           // split and trim the hotkeys string into array
           allowIn = typeof attrs.hotkeyAllowIn === "string" ? attrs.hotkeyAllowIn.split(/[\s,]+/) : [];
 
-          key = hotkey;
+          keys.push(hotkey);
 
           hotkeys.add({
             combo: hotkey,
-            description: attrs.hotkeyDescription,
+            description: description[hotkey],
             callback: func,
             action: attrs.hotkeyAction,
             allowIn: allowIn
@@ -548,7 +551,9 @@
 
         // remove the hotkey if the directive is destroyed:
         el.bind('$destroy', function() {
-          hotkeys.del(key);
+          keys.forEach(function(key) {
+            hotkeys.del(key);
+          });
         });
       }
     };


### PR DESCRIPTION
It seems using the hotkey directive isn't really encouraged, but I believe there's no reason we shouldn't improve it.  If we define more than one combo in the hotkey directive object, the same description in hotkeyDescription attribute would be used for all of them, which made no sense.  This patch generalizes the hotkeyDescription attribute (breaking backward-compatibilty!), so we can easily attach descriptions to each combo.  Also, it fixes a bug that wasn't cleaning up correctly when more than one combo was defined in the directive.