### PR TITLE
Added feature to pause/unpause hotkeys

### DIFF
--- a/src/hotkeys.js
+++ b/src/hotkeys.js
@@ -57,10 +57,24 @@
 
     this.$get = function ($rootElement, $rootScope, $compile, $window, $document) {
 
+      var mouseTrapEnabled = true;
+
+      function pause() {
+        mouseTrapEnabled = false;
+      }
+
+      function unpause() {
+        mouseTrapEnabled = true;
+      }
+
       // monkeypatch Mousetrap's stopCallback() function
       // this version doesn't return true when the element is an INPUT, SELECT, or TEXTAREA
       // (instead we will perform this check per-key in the _add() method)
       Mousetrap.stopCallback = function(event, element) {
+        if (!mouseTrapEnabled) {
+          return true;
+        }
+
         // if the element has the class "mousetrap" then no need to stop
         if ((' ' + element.className + ' ').indexOf(' mousetrap ') > -1) {
           return false;
@@ -505,7 +519,6 @@
         };
       }
 
-
       var publicApi = {
         add                   : _add,
         del                   : _del,
@@ -517,7 +530,9 @@
         cheatSheetHotkey      : this.cheatSheetHotkey,
         cheatSheetDescription : this.cheatSheetDescription,
         purgeHotkeys          : purgeHotkeys,
-        templateTitle         : this.templateTitle
+        templateTitle         : this.templateTitle,
+        pause                 : pause,
+        unpause               : unpause
       };
 
       return publicApi;


### PR DESCRIPTION
As per #86 added a feature to pause/unpause hotkeys.  Based on Mousetrap plugin: https://github.com/ccampbell/mousetrap/blob/master/plugins/pause/mousetrap-pause.js

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/chieffancypants/angular-hotkeys/128)

<!-- Reviewable:end -->
