### PR TITLE
Don't map combo back to hotkey, as that loses information.

### DIFF
--- a/src/hotkeys.js
+++ b/src/hotkeys.js
@@ -500,7 +500,7 @@
           // $apply() to make sure angular's digest happens
           $rootScope.$apply(function() {
             // call the original hotkey callback with the keyboard event
-            callback(event, _get(combo));
+            callback(event, combo);
           });
         };
       }


### PR DESCRIPTION
The callback sometimes needs to know what actual combo was used, for example to decide whether to allow it in a textarea or not (in case some combos in a hotkey have modifiers and others don't).