### PR TITLE
Use strict dependency injection

### DIFF
--- a/src/hotkeys.js
+++ b/src/hotkeys.js
@@ -547,7 +547,7 @@
     };
   })
 
-  .directive('hotkey', function (hotkeys) {
+  .directive('hotkey', ['hotkeys', function (hotkeys) {
     return {
       restrict: 'A',
       link: function (scope, el, attrs) {
@@ -574,7 +574,7 @@
         });
       }
     };
-  })
+  }])
 
   .run(function(hotkeys) {
     // force hotkeys to run by injecting it. Without this, hotkeys only runs

--- a/src/hotkeys.js
+++ b/src/hotkeys.js
@@ -65,7 +65,7 @@
      */
     this.cheatSheetDescription = 'Show / hide this help menu';
 
-    this.$get = function ($rootElement, $rootScope, $compile, $window, $document) {
+    this.$get = ['$rootElement', '$rootScope', '$compile', '$window', '$document', function ($rootElement, $rootScope, $compile, $window, $document) {
 
       // monkeypatch Mousetrap's stopCallback() function
       // this version doesn't return true when the element is an INPUT, SELECT, or TEXTAREA
@@ -544,7 +544,7 @@
 
       return publicApi;
 
-    };
+    }];
   })
 
   .directive('hotkey', ['hotkeys', function (hotkeys) {
@@ -576,9 +576,9 @@
     };
   }])
 
-  .run(function(hotkeys) {
+  .run(['hotkeys', function(hotkeys) {
     // force hotkeys to run by injecting it. Without this, hotkeys only runs
     // when a controller or something else asks for it via DI.
-  });
+  }]);
 
 })();


### PR DESCRIPTION
For minifiers that can't handle ng injection and for projects who enforces ng-strict-di