### PR TITLE
Update hotkeys.css for scroll bar

### DIFF
--- a/src/hotkeys.css
+++ b/src/hotkeys.css
@@ -1,6 +1,7 @@
 .cfp-hotkeys-container {
-  display: table !important;
+  display: block !important;
   position: fixed;
+  overflow: auto;
   width: 100%;
   height: 100%;
   top: 0;
@@ -33,10 +34,11 @@
 }
 
 .cfp-hotkeys {
-  width: 100%;
-  height: 100%;
-  display: table-cell;
+  width: 90%;
   vertical-align: middle;
+  margin-left: auto;  
+  margin-right: auto;
+
 }
 
 .cfp-hotkeys table {


### PR DESCRIPTION
Changed up the CSS a bit to allow the shortcuts help pop-up to be scroll-able when there are more shortcut keys than fit before the fold of the page.
