### PR TITLE
Bugfix: When defining multiple hotkeys, only the last one gets cleane…

### DIFF
--- a/src/hotkeys.js
+++ b/src/hotkeys.js
@@ -551,9 +551,10 @@
     return {
       restrict: 'A',
       link: function (scope, el, attrs) {
-        var key, allowIn;
+        var allowIn;
+        var keys = scope.$eval(attrs.hotkey);
 
-        angular.forEach(scope.$eval(attrs.hotkey), function (func, hotkey) {
+        angular.forEach(keys, function (func, hotkey) {
           // split and trim the hotkeys string into array
           allowIn = typeof attrs.hotkeyAllowIn === "string" ? attrs.hotkeyAllowIn.split(/[\s,]+/) : [];
 
@@ -570,7 +571,9 @@
 
         // remove the hotkey if the directive is destroyed:
         el.bind('$destroy', function() {
-          hotkeys.del(key);
+          angular.forEach(keys, function (func, hotkey) {
+            hotkeys.del(hotkey);
+          });
         });
       }
     };


### PR DESCRIPTION
…d up on .

This fix is pretty self-explanatory.
To reproduce, define a hotkey in a directive like this:
```
<span ng-init="buttonEnabled=true">
<button hotkey:"{x: firstFunction, y: secondFunction}" ng-if="buttonEnabled" ng-click="buttonEnabled=false"></button>
</span>
```

**Expected behaviour**: All hotkeys should be removed/disabled when its $scope is $destroyed (i.e. when the button is pressed)
**Actual behaviour**: Only the last hotkey defined in the object will be removed.