### PR TITLE
fixed race-condition if directive gets replaced

### DIFF
--- a/src/hotkeys.js
+++ b/src/hotkeys.js
@@ -581,8 +581,8 @@
           });
         });
 
-        // remove the hotkey if the directive is destroyed:
-        el.bind('$destroy', function() {
+        // remove the hotkey when the directive-scope gets destroyed:
+        scope.$on('$destroy', function() {
           hotkeys.del(key);
         });
       }


### PR DESCRIPTION
prior when a directive gets replaced by another one with the same binding-key(s) the link-function of the new directive may got called before the $destroy on the element of the first directive.