### PR TITLE
Change boundScopes to object instead of array

### DIFF
--- a/src/hotkeys.js
+++ b/src/hotkeys.js
@@ -215,9 +215,9 @@
        * attached.  This is useful to catch when the scopes are `$destroy`d and
        * then automatically unbind the hotkey.
        *
-       * @type {Array}
+       * @type {Object}
        */
-      var boundScopes = [];
+      var boundScopes = {};
 
       if (this.useNgRoute) {
         $rootScope.$on('$routeChangeSuccess', function (event, route) {


### PR DESCRIPTION
There is an exception that occurs when boundScopes is an array, but treated like a dictionary. When angular.foreach iterates over boundScopes when it is an array, there may be many shadow "undefined" elements in the array when an object is added to it.

var test = [];
test[200] = 'value';
alert(test.length);
// result is 201

since boundScopes is treated like a dictionary, its type should be an object.