### PR TITLE
Bugfix - Deleting multiple keys when the directive is destroyed

### DIFF
--- a/src/hotkeys.js
+++ b/src/hotkeys.js
@@ -584,13 +584,14 @@
     return {
       restrict: 'A',
       link: function (scope, el, attrs) {
-        var key, allowIn;
+        var keys = [],
+            allowIn;
 
         angular.forEach(scope.$eval(attrs.hotkey), function (func, hotkey) {
           // split and trim the hotkeys string into array
           allowIn = typeof attrs.hotkeyAllowIn === "string" ? attrs.hotkeyAllowIn.split(/[\s,]+/) : [];
 
-          key = hotkey;
+          keys.push(hotkey);
 
           hotkeys.add({
             combo: hotkey,
@@ -603,7 +604,7 @@
 
         // remove the hotkey if the directive is destroyed:
         el.bind('$destroy', function() {
-          hotkeys.del(key);
+          angular.forEach(keys, hotkeys.del);
         });
       }
     };

--- a/test/hotkeys.coffee
+++ b/test/hotkeys.coffee
@@ -431,7 +431,7 @@ describe 'Angular Hotkeys', ->
 
 describe 'hotkey directive', ->
 
-  elSimple = elAllowIn = scope = hotkeys = $compile = $document = executedSimple = executedAllowIn = null
+  elSimple = elAllowIn = elMultiple = scope = hotkeys = $compile = $document = executedSimple = executedAllowIn = null
 
   beforeEach ->
     module('cfp.hotkeys')
@@ -447,8 +447,10 @@ describe 'hotkey directive', ->
         executedSimple = yes
       scope.callmeAllowIn = () ->
         executedAllowIn = yes
+      scope.callmeMultiple = () ->
       elSimple = $compile('<div hotkey="{e: callmeSimple}" hotkey-description="testing simple case"></div>')(scope)
       elAllowIn = $compile('<div hotkey="{w: callmeAllowIn}" hotkey-description="testing with allowIn" hotkey-allow-in="INPUT, TEXTAREA"></div>')(scope)
+      elMultiple = $compile('<div hotkey="{a: callmeMultiple, b: callmeMultiple}" hotkey-description="testing with multiple hotkeys"></div>')(scope)
       scope.$digest()
 
   it 'should allow hotkey binding via directive', ->
@@ -475,10 +477,15 @@ describe 'hotkey directive', ->
   it 'should unbind the hotkey when the directive is destroyed', ->
     expect(hotkeys.get('e').combo).toEqual ['e']
     expect(hotkeys.get('w').combo).toEqual ['w']
+    expect(hotkeys.get('a').combo).toEqual ['a']
+    expect(hotkeys.get('b').combo).toEqual ['b']
     elSimple.remove()
     elAllowIn.remove()
+    elMultiple.remove()
     expect(hotkeys.get('e')).toBe no
     expect(hotkeys.get('w')).toBe no
+    expect(hotkeys.get('a')).toBe no
+    expect(hotkeys.get('b')).toBe no
 
 
 describe 'Platform specific things', ->
@@ -581,5 +588,3 @@ describe 'Configuration options', ->
     module 'cfp.hotkeys'
     inject (hotkeys) ->
       expect(hotkeys.useNgRoute).toBe true
-
-


### PR DESCRIPTION
Previously, when a directive links and adds all the keys, it would [only track the last key iterated](https://github.com/chieffancypants/angular-hotkeys/blob/d5dc9566361b5f9a3bda0252271e394353d09508/src/hotkeys.js#L593).

When the directive is destroyed, [only the last key is removed](https://github.com/chieffancypants/angular-hotkeys/blob/d5dc9566361b5f9a3bda0252271e394353d09508/src/hotkeys.js#L606). The others become leaked.

This PR tracks the keys as an array, such that when the directive is destroyed, it ensures all keys are removed by looping through they all the keys that were added.

Tests have been added for this change.