### PR TITLE
Mousetrap as dependency (not devDependency)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,8 +11,10 @@
     "test",
     "example"
   ],
+  "dependencies": {
+    "mousetrap": "~1.5.2"
+  },
   "devDependencies": {
-    "mousetrap": "~1.5.2",
     "angular-mocks": "~1.2.15",
     "angular-route": "~1.2.15"
   }


### PR DESCRIPTION
Mousetrap is needed to load library so it should be put as dependency and not as devDependency.
