### PR TITLE
Update README for `del`

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,12 @@ Removes and unbinds a hotkey
 hotkeys.del('ctrl+w');
 ```
 
+Also accepts an array:
+
+```js
+hotkeys.del(['esc', 'ctrl+w']);
+```
+
 ### Allowing hotkeys in form elements
 By default, Mousetrap prevents hotkey callbacks from firing when their event originates from an `input`, `select`, or `textarea` element. To enable hotkeys in these elements, specify them in the `allowIn` parameter:
 ```js


### PR DESCRIPTION
Reflect that `del` also accepts an array.
