### PR TITLE
Export symbolize in publicApi

### DIFF
--- a/src/hotkeys.js
+++ b/src/hotkeys.js
@@ -586,6 +586,7 @@
         templateTitle         : this.templateTitle,
         pause                 : pause,
         unpause               : unpause
+        symbolize             : symbolize
       };
 
       return publicApi;


### PR DESCRIPTION
Allow users to access the symbolize method so they can use the exact same symbols as used in the cheatsheet.
