### PR TITLE
Fix #211: Expose whether the cheatsheet is visible in the API

### DIFF
--- a/build/hotkeys.js
+++ b/build/hotkeys.js
@@ -325,6 +325,11 @@
         }
       }
 
+      // Helper function to expose helpVisible for the public API
+      function helpVisible() {
+        return scope.helpVisible;
+      }
+
       /**
        * Creates a new Hotkey and creates the Mousetrap binding
        *
@@ -584,6 +589,7 @@
         bindTo                : bindTo,
         template              : this.template,
         toggleCheatSheet      : toggleCheatSheet,
+        helpVisible           : helpVisible,
         includeCheatSheet     : this.includeCheatSheet,
         cheatSheetHotkey      : this.cheatSheetHotkey,
         cheatSheetDescription : this.cheatSheetDescription,

--- a/src/hotkeys.js
+++ b/src/hotkeys.js
@@ -319,6 +319,11 @@
         }
       }
 
+      // Helper function to expose helpVisible for the public API
+      function helpVisible() {
+        return scope.helpVisible;
+      }
+
       /**
        * Creates a new Hotkey and creates the Mousetrap binding
        *
@@ -578,6 +583,7 @@
         bindTo                : bindTo,
         template              : this.template,
         toggleCheatSheet      : toggleCheatSheet,
+        helpVisible           : helpVisible,
         includeCheatSheet     : this.includeCheatSheet,
         cheatSheetHotkey      : this.cheatSheetHotkey,
         cheatSheetDescription : this.cheatSheetDescription,


### PR DESCRIPTION
This more or less obsolesces #211, rather than providing a direct solution. Figure it was safer to just expose visibility rather than exposing multiple entry points to closing the cheatsheet.
