### PR TITLE
Introducing array notation

### DIFF
--- a/src/hotkeys.js
+++ b/src/hotkeys.js
@@ -625,9 +625,9 @@
     };
   }])
 
-  .run(function(hotkeys) {
+  .run(['hotkeys', function(hotkeys) {
     // force hotkeys to run by injecting it. Without this, hotkeys only runs
     // when a controller or something else asks for it via DI.
-  });
+  }]);
 
 })();

--- a/src/hotkeys.js
+++ b/src/hotkeys.js
@@ -11,7 +11,7 @@
 
   'use strict';
 
-  angular.module('cfp.hotkeys', []).provider('hotkeys', function($injector) {
+  angular.module('cfp.hotkeys', []).provider('hotkeys', [function($injector) {
 
     /**
      * Configurable setting to disable the cheatsheet entirely
@@ -593,9 +593,9 @@
     };
 
 
-  })
+  }])
 
-  .directive('hotkey', function (hotkeys) {
+  .directive('hotkey', [function (hotkeys) {
     return {
       restrict: 'A',
       link: function (scope, el, attrs) {
@@ -623,7 +623,7 @@
         });
       }
     };
-  })
+  }])
 
   .run(function(hotkeys) {
     // force hotkeys to run by injecting it. Without this, hotkeys only runs

--- a/src/hotkeys.js
+++ b/src/hotkeys.js
@@ -71,7 +71,7 @@
      */
     this.cheatSheetDescription = 'Show / hide this help menu';
 
-    this.$get = function ($rootElement, $rootScope, $compile, $window, $document) {
+    this.$get = ['$rootElement', '$rootScope', '$compile', '$window', '$document', function ($rootElement, $rootScope, $compile, $window, $document) {
 
       var mouseTrapEnabled = true;
 

--- a/src/hotkeys.js
+++ b/src/hotkeys.js
@@ -11,7 +11,7 @@
 
   'use strict';
 
-  angular.module('cfp.hotkeys', []).provider('hotkeys', [function($injector) {
+  angular.module('cfp.hotkeys', []).provider('hotkeys', ['$injector', function($injector) {
 
     /**
      * Configurable setting to disable the cheatsheet entirely
@@ -595,7 +595,7 @@
 
   }])
 
-  .directive('hotkey', [function (hotkeys) {
+  .directive('hotkey', ['hotkeys', function (hotkeys) {
     return {
       restrict: 'A',
       link: function (scope, el, attrs) {


### PR DESCRIPTION
the minifier can't minify the angular code without array notation.