### PR TITLE
Move mousetrap to dependencies array

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,8 +11,10 @@
     "test",
     "example"
   ],
+  "dependencies": {
+    "mousetrap": "~1.5.2"
+  },
   "devDependencies": {
-    "mousetrap": "~1.5.2",
     "angular-mocks": "~1.2.15",
     "angular-route": "~1.2.15"
   }


### PR DESCRIPTION
This is a run-time dependency, so it doesn't belong in `devDepdencies`.

See #265 