### PR TITLE
add angular as dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,6 +11,9 @@
     "test",
     "example"
   ],
+  "dependencies": {
+    "angular": "1.x"
+  },
   "devDependencies": {
     "mousetrap": "~1.5.2",
     "angular-mocks": "~1.2.15",


### PR DESCRIPTION
angular is a dependency, tools like "wiredep" need to know that angularjs has to be injected before angular-hotkeys.